### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,7 @@
     "node": ">= 0.8.0"
   },
   "author": "sagiv ofek",
-  "license": {
-    "type": "MIT",
-    "url": "http://github.com/assaf/zombie/blob/master/MIT-LICENSE"
-  },
+  "license": "MIT",
   "dependencies": {
     "bitcore": "0.1.41",
     "request": "*"


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)